### PR TITLE
Remove related model data attribute not included

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -20,6 +20,13 @@ module.exports = function format(api, apiReq, apiRes) {
     _.defaults(apiRes.mapperOptions, defaultMapperOptions);
     var mapper = Mapper(api.baseUrl, apiRes.serializerOptions);
     var json = mapper.map(apiRes.model, apiRes.type, apiRes.mapperOptions);
+    var includes = apiReq.query.options.include;
+
+    // Omit data attribute from related models that have not been included
+    // This is a workaround for jsonapi-mapper bug - https://github.com/scoutforpets/jsonapi-mapper/issues/69
+    _.each(json.data.relationships, function (v, k) {
+        json.data.relationships[k] = !_.includes(includes, k) ? _.omit(v, 'data') : v;
+    });
 
     debug('returning');
     return json;


### PR DESCRIPTION
Data attribute for related models that are not included in request should not be returned but their links should

E.g For a subscription model with related plan and user, the following response for `/subscription/38?include=plan`:

```
... (main data removed brevity)
"relationships": {
            "user": {
                "links": {
                    "self": "http://somelink/subscriptions/<id>/relationships/user",
                    "related": "http://somelink/subscriptions/<id>/user"
                }
            },
            "plan": {
                "data": {
                    "type": "plans",
                    "id": "38"
                },
                "links": {
                    "self": "http://somelink/subscriptions/<id>/relationships/plan",
                    "related": "http://somelink/subscriptions/<id>/plan"
                }
            }
        }
```